### PR TITLE
Change: install this library to lib/mlyacc-lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ test: mlyacc-polyml-nodocs
 
 .PHONY: install-nodocs
 install-nodocs: mlyacc-polyml-nodocs
-	install -D -m 0755 -t $(PREFIX)/$(BINDIR) $(BINDIR)/$(MLYACC_POLYML)
-	install -D -m 0644 -t $(PREFIX)/$(LIBDIR) $(LIBDIR)/$(MLYACCLIB)
+	install -D -m 0755 -t $(PREFIX)/$(BINDIR)            $(BINDIR)/$(MLYACC_POLYML)
+	install -D -m 0644 -t $(PREFIX)/$(LIBDIR)/mlyacc-lib $(LIBDIR)/$(MLYACCLIB)
 
 
 .PHONY: install


### PR DESCRIPTION
Change the path to install the library `mlyacc-lib-1.0.0.poly` to `lib/mlyacc-lib`.